### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Determine Docker tag
         id: docker_tag
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
 
 # validate GitHub workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.23.3
+  rev: 0.29.4
   hooks:
     - id: check-github-workflows

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,2 @@
+## Maintainers
+@akaszynski

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Start with the base image
-FROM quay.io/pypa/manylinux2014_x86_64:2023-07-14-55e4124
+FROM quay.io/pypa/manylinux2014_x86_64:2024.11.24-1
 
 # Copy the shell script from your host to the container
 COPY install-opencv-3.4.5-in-centos-7.sh /root/install-opencv-3.4.5-in-centos-7.sh


### PR DESCRIPTION
Update the manylinux2014 base image to 2014.11.24-1 to support Python 3.13.

Thank you to all the people who tirelessly support manylinux and make it possible to run linux wheels on (almost) every glibc.
